### PR TITLE
clean unused untitled images build by packer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for ansible-role-packer-incus
 user: "masum"
 user_pub_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO1BdRWmJL0fFpehq0QsQ7+IchlGYRE+UDGGpvnorhuP khuddin@MacBook-Air-3.local"
+clean_untitled_images: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for ansible-role-packer-incus
 user: "masum"
 user_pub_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO1BdRWmJL0fFpehq0QsQ7+IchlGYRE+UDGGpvnorhuP khuddin@MacBook-Air-3.local"
-clean_untitled_images: False
+clean_untitled_images: false

--- a/files/inc_img_rm.py
+++ b/files/inc_img_rm.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+image = {}
+out = subprocess.getoutput("sudo incus image list -f csv")
+
+for vm in out.splitlines():
+    name = vm.split(',')[0]
+    rm_img = vm.split(',')[1]
+    if len(name) == 0:
+        print("removing image %s" % rm_img)
+        subprocess.getoutput("sudo incus image delete %s" % rm_img)

--- a/files/inc_img_rm.py
+++ b/files/inc_img_rm.py
@@ -2,12 +2,11 @@
 
 import subprocess
 
-image = {}
 out = subprocess.getoutput("sudo incus image list -f csv")
 
 for vm in out.splitlines():
-    name = vm.split(',')[0]
-    rm_img = vm.split(',')[1]
+    name = vm.split(",")[0]
     if len(name) == 0:
+        rm_img = vm.split(",")[1]
         print("removing image %s" % rm_img)
         subprocess.getoutput("sudo incus image delete %s" % rm_img)

--- a/tasks/clean_unnamed_images.yml
+++ b/tasks/clean_unnamed_images.yml
@@ -4,4 +4,4 @@
   args:
     executable: python3
   when:
-    - clean_untitled_images: True
+    - clean_untitled_images | bool

--- a/tasks/clean_unnamed_images.yml
+++ b/tasks/clean_unnamed_images.yml
@@ -1,0 +1,7 @@
+---
+- name: clean title less images
+  script: files/inc_img_rm.py
+  args:
+    executable: python3
+  when:
+    - clean_untitled_images: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,3 +3,4 @@
 - include_tasks: packer_install.yml
 - include_tasks: transfer_files.yml
 - include_tasks: build_image.yml
+- include_tasks: clean_unnamed_images.yml


### PR DESCRIPTION
Packer leaves unnamed, title less images while building custom made images. This script will clean those. By default it will not remove any other images but If you want to remove all untitled images the run following.

should be used with like:
**`ansible-playbook -i inventories/hosts incus-image.yml -e "clean_untitled_images=true"`**
